### PR TITLE
3Dから2Dに変更した際にグリッドヘルパーがON状態にもかかわらずグリッドが消える問題の解決

### DIFF
--- a/src/app/components/three/scene.service.ts
+++ b/src/app/components/three/scene.service.ts
@@ -147,11 +147,9 @@ export class SceneService {
         if (dimension === 2) {
           // 2Dモードであれば、触れないようにする
           camera_gui.domElement.hidden = true;
-          this.GridHelper.visible = false;
           this.OrthographicCamera_onChange(true);
         } else {
           camera_gui.domElement.hidden = false;
-          this.GridHelper.visible = true;
           this.OrthographicCamera_onChange(this.params.Perspective);
         }
         break;


### PR DESCRIPTION
#313 の解決

2Dと3Dの変換時に、
チェックボックスの状態を無視して表示の切り替えを行うような設定であったため、
その切り替え設定を削除した
