### PR TITLE
cdk-virtual-scroll-viewportで部材断面力のテーブルの表示を高速化

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from "@angular/core";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { HttpClientModule, HttpClient } from "@angular/common/http";
 import { DragDropModule } from "@angular/cdk/drag-drop";
+import { ScrollingModule } from '@angular/cdk/scrolling';
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 import { MatRadioModule } from "@angular/material/radio";
 import { NgbModule } from "@ng-bootstrap/ng-bootstrap";
@@ -117,7 +118,8 @@ const httpLoaderFactory = (http: HttpClient): TranslateHttpLoader =>
         deps: [HttpClient],
       },
     }),
-    NgxElectronModule
+    NgxElectronModule,
+    ScrollingModule
   ],
   declarations: [
     AppComponent,

--- a/src/app/components/result/result-combine-fsec/result-combine-fsec.component.html
+++ b/src/app/components/result/result-combine-fsec/result-combine-fsec.component.html
@@ -104,29 +104,33 @@
                                 </thead>
                                 <tbody>
                                     <div *ngIf="dimension===3">
-                                        <tr *ngFor="let resultData of dataset[i]; index as i">
-                                            <td class="result-sm">{{ resultData.m }}</td>
-                                            <td class="result-sm">{{ resultData.n }}</td>
-                                            <td class="result-lg">{{ resultData.l }}</td>
-                                            <td class="result-lg">{{ resultData.fx }}</td>
-                                            <td class="result-lg">{{ resultData.fy }}</td>
-                                            <td class="result-lg">{{ resultData.fz }}</td>
-                                            <td class="result-lg">{{ resultData.mx }}</td>
-                                            <td class="result-lg">{{ resultData.my }}</td>
-                                            <td class="result-lg">{{ resultData.mz }}</td>
-                                            <td class="result-lg">{{ resultData.case }}</td>
-                                        </tr>
+                                        <cdk-virtual-scroll-viewport itemSize="105">       
+                                            <tr *cdkVirtualFor="let resultData of dataset[i]; index as i">
+                                                <td class="result-sm">{{ resultData.m }}</td>
+                                                <td class="result-sm">{{ resultData.n }}</td>
+                                                <td class="result-lg">{{ resultData.l }}</td>
+                                                <td class="result-lg">{{ resultData.fx }}</td>
+                                                <td class="result-lg">{{ resultData.fy }}</td>
+                                                <td class="result-lg">{{ resultData.fz }}</td>
+                                                <td class="result-lg">{{ resultData.mx }}</td>
+                                                <td class="result-lg">{{ resultData.my }}</td>
+                                                <td class="result-lg">{{ resultData.mz }}</td>
+                                                <td class="result-lg">{{ resultData.case }}</td>
+                                            </tr>
+                                        </cdk-virtual-scroll-viewport>
                                     </div>
                                     <div *ngIf="dimension===2">
-                                        <tr *ngFor="let resultData of dataset[i]; index as i">
-                                            <td class="result-sm">{{ resultData.m }}</td>
-                                            <td class="result-sm">{{ resultData.n }}</td>
-                                            <td class="result-lg">{{ resultData.l }}</td>
-                                            <td class="result-lg">{{ resultData.fx }}</td>
-                                            <td class="result-lg">{{ resultData.fy }}</td>
-                                            <td class="result-lg">{{ resultData.mz }}</td>
-                                            <td class="result-lg">{{ resultData.case }}</td>
-                                        </tr>
+                                        <cdk-virtual-scroll-viewport itemSize="105">       
+                                            <tr *cdkVirtualFor="let resultData of dataset[i]; index as i">
+                                                <td class="result-sm">{{ resultData.m }}</td>
+                                                <td class="result-sm">{{ resultData.n }}</td>
+                                                <td class="result-lg">{{ resultData.l }}</td>
+                                                <td class="result-lg">{{ resultData.fx }}</td>
+                                                <td class="result-lg">{{ resultData.fy }}</td>
+                                                <td class="result-lg">{{ resultData.mz }}</td>
+                                                <td class="result-lg">{{ resultData.case }}</td>
+                                            </tr>
+                                        </cdk-virtual-scroll-viewport>
                                     </div>
                                 </tbody>
                             </table>

--- a/src/app/components/result/result-combine-fsec/result-combine-fsec.component.scss
+++ b/src/app/components/result/result-combine-fsec/result-combine-fsec.component.scss
@@ -1,3 +1,9 @@
 tbody {
-    max-height: calc(100vh - 750px);
+    max-height: calc(100vh - 500px);
+}
+// tbody {
+//     max-height: calc(100vh - 750px);
+// }
+.cdk-virtual-scroll-viewport {
+    height: calc(100vh - 500px);
 }

--- a/src/app/components/result/result-fsec/result-fsec.component.html
+++ b/src/app/components/result/result-fsec/result-fsec.component.html
@@ -94,28 +94,18 @@
                                 <td class="result-lg">{{ resultData.mz }}</td>
                             </tr>
                         </cdk-virtual-scroll-viewport>
-                           
-                        <!-- <tr *ngFor="let resultData of dataset; index as i">
-                            <td class="result-sm">{{ resultData.m }}</td>
-                            <td class="result-sm">{{ resultData.n }}</td>
-                            <td class="result-lg">{{ resultData.l }}</td>
-                            <td class="result-lg">{{ resultData.fx }}</td>
-                            <td class="result-lg">{{ resultData.fy }}</td>
-                            <td class="result-lg">{{ resultData.fz }}</td>
-                            <td class="result-lg">{{ resultData.mx }}</td>
-                            <td class="result-lg">{{ resultData.my }}</td>
-                            <td class="result-lg">{{ resultData.mz }}</td>
-                        </tr> -->
                     </div>
                     <div *ngIf="dimension===2">
-                        <tr *ngFor="let resultData of dataset; index as i">
-                            <td class="result-sm">{{ resultData.m }}</td>
-                            <td class="result-sm">{{ resultData.n }}</td>
-                            <td class="result-lg">{{ resultData.l }}</td>
-                            <td class="result-lg">{{ resultData.fx }}</td>
-                            <td class="result-lg">{{ resultData.fy }}</td>
-                            <td class="result-lg">{{ resultData.mz }}</td>
-                        </tr>
+                        <cdk-virtual-scroll-viewport itemSize="25">       
+                            <tr *cdkVirtualFor="let resultData of dataset; index as i">
+                                <td class="result-sm">{{ resultData.m }}</td>
+                                <td class="result-sm">{{ resultData.n }}</td>
+                                <td class="result-lg">{{ resultData.l }}</td>
+                                <td class="result-lg">{{ resultData.fx }}</td>
+                                <td class="result-lg">{{ resultData.fy }}</td>
+                                <td class="result-lg">{{ resultData.mz }}</td>
+                            </tr>
+                        </cdk-virtual-scroll-viewport>
                     </div>
                 </tbody>
             </table>

--- a/src/app/components/result/result-fsec/result-fsec.component.html
+++ b/src/app/components/result/result-fsec/result-fsec.component.html
@@ -81,7 +81,21 @@
                 </thead>
                 <tbody>
                     <div *ngIf="dimension===3">
-                        <tr *ngFor="let resultData of dataset; index as i">
+                        <cdk-virtual-scroll-viewport itemSize="25">       
+                            <tr *cdkVirtualFor="let resultData of dataset; index as i">
+                                <td class="result-sm">{{ resultData.m }}</td>
+                                <td class="result-sm">{{ resultData.n }}</td>
+                                <td class="result-lg">{{ resultData.l }}</td>
+                                <td class="result-lg">{{ resultData.fx }}</td>
+                                <td class="result-lg">{{ resultData.fy }}</td>
+                                <td class="result-lg">{{ resultData.fz }}</td>
+                                <td class="result-lg">{{ resultData.mx }}</td>
+                                <td class="result-lg">{{ resultData.my }}</td>
+                                <td class="result-lg">{{ resultData.mz }}</td>
+                            </tr>
+                        </cdk-virtual-scroll-viewport>
+                           
+                        <!-- <tr *ngFor="let resultData of dataset; index as i">
                             <td class="result-sm">{{ resultData.m }}</td>
                             <td class="result-sm">{{ resultData.n }}</td>
                             <td class="result-lg">{{ resultData.l }}</td>
@@ -91,7 +105,7 @@
                             <td class="result-lg">{{ resultData.mx }}</td>
                             <td class="result-lg">{{ resultData.my }}</td>
                             <td class="result-lg">{{ resultData.mz }}</td>
-                        </tr>
+                        </tr> -->
                     </div>
                     <div *ngIf="dimension===2">
                         <tr *ngFor="let resultData of dataset; index as i">

--- a/src/app/components/result/result-fsec/result-fsec.component.scss
+++ b/src/app/components/result/result-fsec/result-fsec.component.scss
@@ -2,3 +2,6 @@ tbody {
     max-height: calc(100vh - 450px);
 }
 
+.cdk-virtual-scroll-viewport {
+    height: calc(100vh - 450px);
+}

--- a/src/app/components/result/result-pickup-fsec/result-pickup-fsec.component.html
+++ b/src/app/components/result/result-pickup-fsec/result-pickup-fsec.component.html
@@ -104,29 +104,33 @@
                                 </thead>
                                 <tbody>
                                     <div *ngIf="dimension===3">
-                                        <tr *ngFor="let resultData of dataset[i]; index as i">
-                                            <td class="result-sm">{{ resultData.m }}</td>
-                                            <td class="result-sm">{{ resultData.n }}</td>
-                                            <td class="result-lg">{{ resultData.l }}</td>
-                                            <td class="result-lg">{{ resultData.fx }}</td>
-                                            <td class="result-lg">{{ resultData.fy }}</td>
-                                            <td class="result-lg">{{ resultData.fz }}</td>
-                                            <td class="result-lg">{{ resultData.mx }}</td>
-                                            <td class="result-lg">{{ resultData.my }}</td>
-                                            <td class="result-lg">{{ resultData.mz }}</td>
-                                            <td class="result-lg">{{ resultData.case }}</td>
-                                        </tr>
+                                        <cdk-virtual-scroll-viewport itemSize="105">       
+                                            <tr *cdkVirtualFor="let resultData of dataset[i]; index as i">
+                                                <td class="result-sm">{{ resultData.m }}</td>
+                                                <td class="result-sm">{{ resultData.n }}</td>
+                                                <td class="result-lg">{{ resultData.l }}</td>
+                                                <td class="result-lg">{{ resultData.fx }}</td>
+                                                <td class="result-lg">{{ resultData.fy }}</td>
+                                                <td class="result-lg">{{ resultData.fz }}</td>
+                                                <td class="result-lg">{{ resultData.mx }}</td>
+                                                <td class="result-lg">{{ resultData.my }}</td>
+                                                <td class="result-lg">{{ resultData.mz }}</td>
+                                                <td class="result-lg">{{ resultData.case }}</td>
+                                            </tr>
+                                        </cdk-virtual-scroll-viewport>
                                     </div>
                                     <div *ngIf="dimension===2">
-                                        <tr *ngFor="let resultData of dataset[i]; index as i">
-                                            <td class="result-sm">{{ resultData.m }}</td>
-                                            <td class="result-sm">{{ resultData.n }}</td>
-                                            <td class="result-lg">{{ resultData.l }}</td>
-                                            <td class="result-lg">{{ resultData.fx }}</td>
-                                            <td class="result-lg">{{ resultData.fy }}</td>
-                                            <td class="result-lg">{{ resultData.mz }}</td>
-                                            <td class="result-lg">{{ resultData.case }}</td>
-                                        </tr>
+                                        <cdk-virtual-scroll-viewport itemSize="105">       
+                                            <tr *cdkVirtualFor="let resultData of dataset[i]; index as i">
+                                                <td class="result-sm">{{ resultData.m }}</td>
+                                                <td class="result-sm">{{ resultData.n }}</td>
+                                                <td class="result-lg">{{ resultData.l }}</td>
+                                                <td class="result-lg">{{ resultData.fx }}</td>
+                                                <td class="result-lg">{{ resultData.fy }}</td>
+                                                <td class="result-lg">{{ resultData.mz }}</td>
+                                                <td class="result-lg">{{ resultData.case }}</td>
+                                            </tr>
+                                        </cdk-virtual-scroll-viewport>
                                     </div>
                                 </tbody>
                             </table>


### PR DESCRIPTION
Three.js レンダリングをまだ更新していません。
まだ理想的な速度ではありませんが、ちょと改善されています.