### PR TITLE
着目点の点モデルを作成、節点・部材・荷重の入力セルを選択時に選択対象を円で強調する機能の追加

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from "@angular/core";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { HttpClientModule, HttpClient } from "@angular/common/http";
 import { DragDropModule } from "@angular/cdk/drag-drop";
+import { ScrollingModule } from '@angular/cdk/scrolling';
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 import { MatRadioModule } from "@angular/material/radio";
 import { NgbModule } from "@ng-bootstrap/ng-bootstrap";
@@ -117,7 +118,8 @@ const httpLoaderFactory = (http: HttpClient): TranslateHttpLoader =>
         deps: [HttpClient],
       },
     }),
-    NgxElectronModule
+    NgxElectronModule,
+    ScrollingModule
   ],
   declarations: [
     AppComponent,

--- a/src/app/components/input/input-members/input-members.component.ts
+++ b/src/app/components/input/input-members/input-members.component.ts
@@ -241,11 +241,11 @@ export class InputMembersComponent implements OnInit {
       const range = ui.selection.iCells.ranges;
       const row = range[0].r1 + 1;
       const column = this.columnKeys[range[0].c1];
-      if (this.currentIndex !== row){
+      // if (this.currentIndex !== row){
         //選択行の変更があるとき，ハイライトを実行する
         this.three.selectChange("members", row, '');
-      }
-      this.currentIndex = row;
+      // }
+      // this.currentIndex = row;
     },
     change: (evt, ui) => {
       const changes = ui.updateList;

--- a/src/app/components/input/input-members/input-members.service.ts
+++ b/src/app/components/input/input-members/input-members.service.ts
@@ -7,6 +7,7 @@ import { InputNodesService } from '../input-nodes/input-nodes.service';
 })
 export class InputMembersService {
   public member: any[];
+  public points: any[];
 
   constructor(private node: InputNodesService,
               private helper: DataHelperModule) {
@@ -15,6 +16,7 @@ export class InputMembersService {
 
   public clear(): void {
     this.member = new Array();
+    this.points = new Array();
   }
   
   public getMemberColumns(index: number): any {
@@ -105,6 +107,43 @@ export class InputMembersService {
 
     return member;
 
+  }
+
+  public getAxis(memberNo: string, m_len: number, m_length: number):any {
+
+    const memb = this.getMember(memberNo.toString());
+    if (memb.ni === undefined || memb.nj === undefined) {
+      return null;
+    }
+
+    const ni: string = memb.ni;
+    const nj: string = memb.nj;
+    if (ni === null || nj === null) {
+      return null;
+    }
+
+    const iPos = this.node.getNodePos(ni)
+    const jPos = this.node.getNodePos(nj)
+    if (iPos == null || jPos == null) {
+      return null;
+    }
+
+    const xi: number = iPos['x'];
+    const yi: number = iPos['y'];
+    const zi: number = iPos['z'];
+    const xj: number = jPos['x'];
+    const yj: number = jPos['y'];
+    const zj: number = jPos['z'];
+
+    const x: string = (xi + (xj - xi) * m_length / m_len).toFixed(3);
+    const y: string = (yi + (yj - yi) * m_length / m_len).toFixed(3);
+    const z: string = (zi + (zj - zi) * m_length / m_len).toFixed(3);
+
+    return {
+      x,
+      y,
+      z
+    };
   }
 
   public getMemberLength(memberNo: string): number {

--- a/src/app/components/input/input-nodes/input-nodes.component.ts
+++ b/src/app/components/input/input-nodes/input-nodes.component.ts
@@ -97,11 +97,11 @@ export class InputNodesComponent implements OnInit {
       const range = ui.selection.iCells.ranges;
       const row = range[0].r1 + 1;
       const column = this.columnKeys[range[0].c1];
-      if (this.currentRow !== row){
+      // if (this.currentRow !== row){
         //選択行の変更があるとき，ハイライトを実行する
-        this.three.selectChange('nodes', row, '');
-      }
-      this.currentRow = row;
+      this.three.selectChange('nodes', row, '');
+      // }
+      // this.currentRow = row;
     },
     change: (evt, ui) => {
       const changes = ui.updateList;

--- a/src/app/components/input/input-notice-points/input-notice-points.component.ts
+++ b/src/app/components/input/input-notice-points/input-notice-points.component.ts
@@ -8,6 +8,8 @@ import pq from "pqgrid";
 import { AppComponent } from "src/app/app.component";
 import { TranslateService } from "@ngx-translate/core";
 
+import * as THREE from 'three';
+
 @Component({
   selector: "app-input-notice-points",
   templateUrl: "./input-notice-points.component.html",
@@ -78,6 +80,7 @@ export class InputNoticePointsComponent implements OnInit {
     this.ROWS_COUNT = this.rowsCount();
     // three.js にモードの変更を通知する
     this.three.ChangeMode("notice_points");
+    this.three.changeData('notice-points');
   }
 
   // 指定行row 以降のデータを読み取る
@@ -136,10 +139,10 @@ export class InputNoticePointsComponent implements OnInit {
       const range = ui.selection.iCells.ranges;
       const row = range[0].r1 + 1;
       const column = this.columnKeys[range[0].c1];
-      if (this.currentIndex !== row){
+      // if (this.currentIndex !== row){
         //選択行の変更があるとき，ハイライトを実行する
         this.three.selectChange("notice-points", row, column);
-      }
+      // }
       this.currentIndex = row;
     },
     change: (evt, ui) => {

--- a/src/app/components/input/input-notice-points/input-notice-points.service.ts
+++ b/src/app/components/input/input-notice-points/input-notice-points.service.ts
@@ -18,7 +18,6 @@ export class InputNoticePointsService {
 
   public getNoticePointsColumns(row: number): any {
     let result: any = null;
-
     for (const tmp of this.notice_points) {
       if (tmp["row"] === row) {
         result = tmp;
@@ -92,7 +91,6 @@ export class InputNoticePointsService {
         Points: points,
       });
     }
-
     return result;
   }
 }

--- a/src/app/components/input/input-panel/input-panel.service.ts
+++ b/src/app/components/input/input-panel/input-panel.service.ts
@@ -43,7 +43,7 @@ export class InputPanelService {
   }
 
   public setPanelJson(jsonData: {}): void {
-    console.log('setPanelJson', jsonData);
+    // console.log('setPanelJson', jsonData);
     if (!('shell' in jsonData)) {
       return;
     }

--- a/src/app/components/result/result-combine-fsec/result-combine-fsec.component.html
+++ b/src/app/components/result/result-combine-fsec/result-combine-fsec.component.html
@@ -104,29 +104,33 @@
                                 </thead>
                                 <tbody>
                                     <div *ngIf="dimension===3">
-                                        <tr *ngFor="let resultData of dataset[i]; index as i">
-                                            <td class="result-sm">{{ resultData.m }}</td>
-                                            <td class="result-sm">{{ resultData.n }}</td>
-                                            <td class="result-lg">{{ resultData.l }}</td>
-                                            <td class="result-lg">{{ resultData.fx }}</td>
-                                            <td class="result-lg">{{ resultData.fy }}</td>
-                                            <td class="result-lg">{{ resultData.fz }}</td>
-                                            <td class="result-lg">{{ resultData.mx }}</td>
-                                            <td class="result-lg">{{ resultData.my }}</td>
-                                            <td class="result-lg">{{ resultData.mz }}</td>
-                                            <td class="result-lg">{{ resultData.case }}</td>
-                                        </tr>
+                                        <cdk-virtual-scroll-viewport itemSize="105">       
+                                            <tr *cdkVirtualFor="let resultData of dataset[i]; index as i">
+                                                <td class="result-sm">{{ resultData.m }}</td>
+                                                <td class="result-sm">{{ resultData.n }}</td>
+                                                <td class="result-lg">{{ resultData.l }}</td>
+                                                <td class="result-lg">{{ resultData.fx }}</td>
+                                                <td class="result-lg">{{ resultData.fy }}</td>
+                                                <td class="result-lg">{{ resultData.fz }}</td>
+                                                <td class="result-lg">{{ resultData.mx }}</td>
+                                                <td class="result-lg">{{ resultData.my }}</td>
+                                                <td class="result-lg">{{ resultData.mz }}</td>
+                                                <td class="result-lg">{{ resultData.case }}</td>
+                                            </tr>
+                                        </cdk-virtual-scroll-viewport>
                                     </div>
                                     <div *ngIf="dimension===2">
-                                        <tr *ngFor="let resultData of dataset[i]; index as i">
-                                            <td class="result-sm">{{ resultData.m }}</td>
-                                            <td class="result-sm">{{ resultData.n }}</td>
-                                            <td class="result-lg">{{ resultData.l }}</td>
-                                            <td class="result-lg">{{ resultData.fx }}</td>
-                                            <td class="result-lg">{{ resultData.fy }}</td>
-                                            <td class="result-lg">{{ resultData.mz }}</td>
-                                            <td class="result-lg">{{ resultData.case }}</td>
-                                        </tr>
+                                        <cdk-virtual-scroll-viewport itemSize="105">       
+                                            <tr *cdkVirtualFor="let resultData of dataset[i]; index as i">
+                                                <td class="result-sm">{{ resultData.m }}</td>
+                                                <td class="result-sm">{{ resultData.n }}</td>
+                                                <td class="result-lg">{{ resultData.l }}</td>
+                                                <td class="result-lg">{{ resultData.fx }}</td>
+                                                <td class="result-lg">{{ resultData.fy }}</td>
+                                                <td class="result-lg">{{ resultData.mz }}</td>
+                                                <td class="result-lg">{{ resultData.case }}</td>
+                                            </tr>
+                                        </cdk-virtual-scroll-viewport>
                                     </div>
                                 </tbody>
                             </table>

--- a/src/app/components/result/result-combine-fsec/result-combine-fsec.component.scss
+++ b/src/app/components/result/result-combine-fsec/result-combine-fsec.component.scss
@@ -1,3 +1,9 @@
 tbody {
-    max-height: calc(100vh - 750px);
+    max-height: calc(100vh - 500px);
+}
+// tbody {
+//     max-height: calc(100vh - 750px);
+// }
+.cdk-virtual-scroll-viewport {
+    height: calc(100vh - 500px);
 }

--- a/src/app/components/result/result-fsec/result-fsec.component.html
+++ b/src/app/components/result/result-fsec/result-fsec.component.html
@@ -81,27 +81,31 @@
                 </thead>
                 <tbody>
                     <div *ngIf="dimension===3">
-                        <tr *ngFor="let resultData of dataset; index as i">
-                            <td class="result-sm">{{ resultData.m }}</td>
-                            <td class="result-sm">{{ resultData.n }}</td>
-                            <td class="result-lg">{{ resultData.l }}</td>
-                            <td class="result-lg">{{ resultData.fx }}</td>
-                            <td class="result-lg">{{ resultData.fy }}</td>
-                            <td class="result-lg">{{ resultData.fz }}</td>
-                            <td class="result-lg">{{ resultData.mx }}</td>
-                            <td class="result-lg">{{ resultData.my }}</td>
-                            <td class="result-lg">{{ resultData.mz }}</td>
-                        </tr>
+                        <cdk-virtual-scroll-viewport itemSize="25">       
+                            <tr *cdkVirtualFor="let resultData of dataset; index as i">
+                                <td class="result-sm">{{ resultData.m }}</td>
+                                <td class="result-sm">{{ resultData.n }}</td>
+                                <td class="result-lg">{{ resultData.l }}</td>
+                                <td class="result-lg">{{ resultData.fx }}</td>
+                                <td class="result-lg">{{ resultData.fy }}</td>
+                                <td class="result-lg">{{ resultData.fz }}</td>
+                                <td class="result-lg">{{ resultData.mx }}</td>
+                                <td class="result-lg">{{ resultData.my }}</td>
+                                <td class="result-lg">{{ resultData.mz }}</td>
+                            </tr>
+                        </cdk-virtual-scroll-viewport>
                     </div>
                     <div *ngIf="dimension===2">
-                        <tr *ngFor="let resultData of dataset; index as i">
-                            <td class="result-sm">{{ resultData.m }}</td>
-                            <td class="result-sm">{{ resultData.n }}</td>
-                            <td class="result-lg">{{ resultData.l }}</td>
-                            <td class="result-lg">{{ resultData.fx }}</td>
-                            <td class="result-lg">{{ resultData.fy }}</td>
-                            <td class="result-lg">{{ resultData.mz }}</td>
-                        </tr>
+                        <cdk-virtual-scroll-viewport itemSize="25">       
+                            <tr *cdkVirtualFor="let resultData of dataset; index as i">
+                                <td class="result-sm">{{ resultData.m }}</td>
+                                <td class="result-sm">{{ resultData.n }}</td>
+                                <td class="result-lg">{{ resultData.l }}</td>
+                                <td class="result-lg">{{ resultData.fx }}</td>
+                                <td class="result-lg">{{ resultData.fy }}</td>
+                                <td class="result-lg">{{ resultData.mz }}</td>
+                            </tr>
+                        </cdk-virtual-scroll-viewport>
                     </div>
                 </tbody>
             </table>

--- a/src/app/components/result/result-fsec/result-fsec.component.scss
+++ b/src/app/components/result/result-fsec/result-fsec.component.scss
@@ -2,3 +2,6 @@ tbody {
     max-height: calc(100vh - 450px);
 }
 
+.cdk-virtual-scroll-viewport {
+    height: calc(100vh - 450px);
+}

--- a/src/app/components/result/result-fsec/result-fsec.component.ts
+++ b/src/app/components/result/result-fsec/result-fsec.component.ts
@@ -8,7 +8,6 @@ import { ResultCombineFsecService } from "../result-combine-fsec/result-combine-
 import { ResultPickupFsecService } from "../result-pickup-fsec/result-pickup-fsec.service";
 import { AppComponent } from "src/app/app.component";
 import { DataHelperModule } from "src/app/providers/data-helper.module";
-import { ThreeSectionForceService } from "../../three/geometry/three-section-force/three-section-force.service";
 
 @Component({
   selector: "app-result-fsec",
@@ -42,8 +41,7 @@ export class ResultFsecComponent implements OnInit {
     private three: ThreeService,
     private comb: ResultCombineFsecService,
     private pic: ResultPickupFsecService,
-    private helper: DataHelperModule,
-    private fsec: ThreeSectionForceService,
+    private helper: DataHelperModule
   ) {
     this.dataset = new Array();
     this.dimension = this.helper.dimension;
@@ -53,18 +51,14 @@ export class ResultFsecComponent implements OnInit {
       this.circleBox.push(i);
     }
 
-    if (this.result.case != "basic") {
+    if(this.result.case != "basic"){
       this.result.page = 1
       this.result.case = "basic"
     }
   }
 
   ngOnInit() {
-    // グローバル・パラメータをリセットする
-    this.fsec.resetGuiParams();
-
     this.loadPage(this.result.page);
-
     setTimeout(() => {
       const circle = document.getElementById(String(this.cal + 20));
       if (circle !== null) {
@@ -101,18 +95,18 @@ export class ResultFsecComponent implements OnInit {
 
     this.load_name = this.load.getLoadName(currentPage);
 
-    if (this.result.page <= this.data.LL_flg.length) {
-      this.LL_page = this.data.LL_flg[this.result.page - 1];
+    if(this.result.page <= this.data.LL_flg.length){
+      this.LL_page =this.data.LL_flg[this.result.page - 1];
     } else {
       this.LL_page = false;
     }
-
-    if (this.LL_page === true) {
+    
+    if(this.LL_page===true){
       this.dataset = new Array();
       for (const key of this.KEYS) {
         this.dataset.push(this.data.getFsecColumns(this.result.page, key));
       }
-    } else {
+    } else{
       this.dataset = this.data.getFsecColumns(this.result.page);
     }
 

--- a/src/app/components/result/result-pickup-fsec/result-pickup-fsec.component.html
+++ b/src/app/components/result/result-pickup-fsec/result-pickup-fsec.component.html
@@ -104,29 +104,33 @@
                                 </thead>
                                 <tbody>
                                     <div *ngIf="dimension===3">
-                                        <tr *ngFor="let resultData of dataset[i]; index as i">
-                                            <td class="result-sm">{{ resultData.m }}</td>
-                                            <td class="result-sm">{{ resultData.n }}</td>
-                                            <td class="result-lg">{{ resultData.l }}</td>
-                                            <td class="result-lg">{{ resultData.fx }}</td>
-                                            <td class="result-lg">{{ resultData.fy }}</td>
-                                            <td class="result-lg">{{ resultData.fz }}</td>
-                                            <td class="result-lg">{{ resultData.mx }}</td>
-                                            <td class="result-lg">{{ resultData.my }}</td>
-                                            <td class="result-lg">{{ resultData.mz }}</td>
-                                            <td class="result-lg">{{ resultData.case }}</td>
-                                        </tr>
+                                        <cdk-virtual-scroll-viewport itemSize="105">       
+                                            <tr *cdkVirtualFor="let resultData of dataset[i]; index as i">
+                                                <td class="result-sm">{{ resultData.m }}</td>
+                                                <td class="result-sm">{{ resultData.n }}</td>
+                                                <td class="result-lg">{{ resultData.l }}</td>
+                                                <td class="result-lg">{{ resultData.fx }}</td>
+                                                <td class="result-lg">{{ resultData.fy }}</td>
+                                                <td class="result-lg">{{ resultData.fz }}</td>
+                                                <td class="result-lg">{{ resultData.mx }}</td>
+                                                <td class="result-lg">{{ resultData.my }}</td>
+                                                <td class="result-lg">{{ resultData.mz }}</td>
+                                                <td class="result-lg">{{ resultData.case }}</td>
+                                            </tr>
+                                        </cdk-virtual-scroll-viewport>
                                     </div>
                                     <div *ngIf="dimension===2">
-                                        <tr *ngFor="let resultData of dataset[i]; index as i">
-                                            <td class="result-sm">{{ resultData.m }}</td>
-                                            <td class="result-sm">{{ resultData.n }}</td>
-                                            <td class="result-lg">{{ resultData.l }}</td>
-                                            <td class="result-lg">{{ resultData.fx }}</td>
-                                            <td class="result-lg">{{ resultData.fy }}</td>
-                                            <td class="result-lg">{{ resultData.mz }}</td>
-                                            <td class="result-lg">{{ resultData.case }}</td>
-                                        </tr>
+                                        <cdk-virtual-scroll-viewport itemSize="105">       
+                                            <tr *cdkVirtualFor="let resultData of dataset[i]; index as i">
+                                                <td class="result-sm">{{ resultData.m }}</td>
+                                                <td class="result-sm">{{ resultData.n }}</td>
+                                                <td class="result-lg">{{ resultData.l }}</td>
+                                                <td class="result-lg">{{ resultData.fx }}</td>
+                                                <td class="result-lg">{{ resultData.fy }}</td>
+                                                <td class="result-lg">{{ resultData.mz }}</td>
+                                                <td class="result-lg">{{ resultData.case }}</td>
+                                            </tr>
+                                        </cdk-virtual-scroll-viewport>
                                     </div>
                                 </tbody>
                             </table>

--- a/src/app/components/three/geometry/three-load/three-load.service.ts
+++ b/src/app/components/three/geometry/three-load/three-load.service.ts
@@ -364,7 +364,6 @@ export class ThreeLoadService {
     for (let child of ThreeObject.children) {
       const item: any = child;
       if (!("editor" in item)) continue;
-
       const editor: any = item["editor"];
 
       let column = ``;
@@ -378,6 +377,7 @@ export class ThreeLoadService {
         if (editor.id !== "PointLoad" && editor.id !== "MomentLoad") {
           if (item.name.indexOf(key) !== -1) {
             editor.setColor(item, "select");
+            this.scene.getScreenPosition(item);
           } else {
             editor.setColor(item, "clear");
           }
@@ -388,6 +388,7 @@ export class ThreeLoadService {
         if (editor.id === "PointLoad" || editor.id === "MomentLoad") {
           if (item.name.indexOf(key) !== -1) {
             editor.setColor(item, "select");
+            this.scene.getScreenPosition(item);
           } else {
             editor.setColor(item, "clear");
           }

--- a/src/app/components/three/geometry/three-members.service.ts
+++ b/src/app/components/three/geometry/three-members.service.ts
@@ -197,6 +197,7 @@ export class ThreeMembersService {
       } else {
         if (item.name === 'member' + index.toString()){
           item['material']['color'].setHex(0XFF0000);
+          this.scene.getScreenPosition(item);
         }
       }
     }
@@ -234,6 +235,16 @@ export class ThreeMembersService {
       if (item.name === 'member' + m_no.toString()){
         item['material']['color'].setHex(0XFF0000);
       }
+    }
+
+  }
+
+  // 着目点のselectChange
+  public selectChange_clear_points(): void {
+
+    // 全てのハイライトを元に戻し，選択行のオブジェクトのみハイライトを適応する
+    for (let item of this.memberList.children){
+      item['material']['color'].setHex(0X000000);
     }
 
   }

--- a/src/app/components/three/geometry/three-nodes.service.ts
+++ b/src/app/components/three/geometry/three-nodes.service.ts
@@ -4,6 +4,8 @@ import { InputNodesService } from '../../../components/input/input-nodes/input-n
 import * as THREE from 'three';
 import { CSS2DObject } from '../libs/CSS2DRenderer.js';
 
+import { TWEEN } from 'three/examples/jsm/libs/tween.module.min'
+
 @Injectable({
   providedIn: 'root'
 })
@@ -15,6 +17,7 @@ export class ThreeNodesService {
 
   public maxDistance: number;
   public minDistance: number;
+  private currentIndex: string;
 
   private nodeList: THREE.Object3D;
   private selectionItem: THREE.Object3D;     // 選択中のアイテム
@@ -74,7 +77,6 @@ export class ThreeNodesService {
       this.ClearData();
       return null;
     }
-
     // 入力データに無い要素を排除する
     for (let i = this.nodeList.children.length - 1; i >= 0; i--) {
       const item = jsonKeys.find((key) => {
@@ -133,6 +135,26 @@ export class ThreeNodesService {
     return jsonData;
   }
 
+//   public toScreenPosition(obj, camera)
+// {
+//     var vector = new THREE.Vector3();
+
+//     var widthHalf = 0.5*renderer.context.canvas.width;
+//     var heightHalf = 0.5*renderer.context.canvas.height;
+
+//     obj.updateMatrixWorld();
+//     vector.setFromMatrixPosition(obj.matrixWorld);
+//     vector.project(camera);
+
+//     vector.x = ( vector.x * widthHalf ) + widthHalf;
+//     vector.y = - ( vector.y * heightHalf ) + heightHalf;
+
+//     return { 
+//         x: vector.x,
+//         y: vector.y
+//     };
+
+// };
   //シートの選択行が指すオブジェクトをハイライトする
   public selectChange(index): void{
 
@@ -140,7 +162,6 @@ export class ThreeNodesService {
     //   //選択行の変更がないとき，何もしない
     //   return
     // }
-
     //全てのハイライトを元に戻し，選択行のオブジェクトのみハイライトを適応する
     for (let item of this.nodeList.children){
 
@@ -149,6 +170,11 @@ export class ThreeNodesService {
       if (item.name === 'node' + index.toString()){
 
         item['material']['color'].setHex(0X00A5FF);
+
+        this.scene.getScreenPosition(item);
+
+        // item['scale']['x']
+
       }
     }
 

--- a/src/app/components/three/geometry/three-section-force/three-section-force.service.ts
+++ b/src/app/components/three/geometry/three-section-force/three-section-force.service.ts
@@ -143,11 +143,6 @@ export class ThreeSectionForceService {
       this.params[key] = false;
     }
 
-    this.resetGuiParams();
-  }
-
-  // パラメータを2D|3Dに応じてリセット
-  public resetGuiParams(): void {
     if (this.helper.dimension === 3) {
       this.params.momentY = true; // 初期値（3D）
       this.currentRadio = "momentY";
@@ -177,6 +172,14 @@ export class ThreeSectionForceService {
         }),
     };
 
+    // this.gui['textCount'] = this.scene.gui.add(this.params, 'textCount', 0, 100).step(10).onFinishChange((value) => {
+    //   // guiによる設定
+    //   this.textCount = value;
+    //   this.changeMesh();
+    //   this.onResize();
+    //   this.scene.render();
+    // });
+
     for (const key of this.radioButtons) {
       this.gui[key] = this.scene.gui
         .add(this.params, key, this.params[key])
@@ -189,10 +192,10 @@ export class ThreeSectionForceService {
           }
           this.changeMesh();
           const key1: string =
-            (key === 'axialForce' || key === 'torsionalMorment') ? 'x' :
-              (key === 'shearForceY' || key === 'momentY') ? 'y' : 'z';
+          ( key === 'axialForce' || key === 'torsionalMorment' ) ? 'x' :
+          ( key === 'shearForceY' || key === 'momentY' ) ? 'y' : 'z';
           this.max_min._getMaxMinValue(
-            this.value_ranges[this.currentMode][this.currentIndex][key1],
+            this.value_ranges[this.currentMode][this.currentIndex][key1], 
             'fsec',
             this.currentRadio
           );
@@ -410,28 +413,28 @@ export class ThreeSectionForceService {
           L2 = Math.round((len - LL) * 1000) / 1000;
           if (item === null) {
             const mesh = this.mesh.create(
-              nodei,
-              nodej,
-              localAxis,
-              key2,
-              L1,
-              L2,
-              P1,
-              P2
-            );
+                    nodei,
+                    nodej,
+                    localAxis,
+                    key2,
+                    L1,
+                    L2,
+                    P1,
+                    P2
+                  );
             ThreeObject.add(mesh);
           } else {
-            this.mesh.change(
-              item,
-              nodei,
-              nodej,
-              localAxis,
-              key2,
-              L1,
-              L2,
-              P1,
-              P2
-            );
+              this.mesh.change(
+                item,
+                nodei,
+                nodej,
+                localAxis,
+                key2,
+                L1,
+                L2,
+                P1,
+                P2
+              );
           }
           P1 = P2;
           L1 = LL;

--- a/src/app/components/three/scene.service.ts
+++ b/src/app/components/three/scene.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@angular/core";
+import { Injectable,ElementRef } from "@angular/core";
 import * as THREE from "three";
 import { ThreeComponent } from "./three.component";
 import { GUI } from "./libs/dat.gui.module.js";
@@ -22,6 +22,7 @@ export class SceneService {
 
   // ギズモ
   private controlsGizmo: HTMLCanvasElement = null;
+  private id = null;
   //private controlsGizmoParent: OrbitControlsGizmo;
 
   // カメラ
@@ -165,7 +166,6 @@ export class SceneService {
 
     this.initCamera();  // カメラをシーンに登録する
     this.controls.object = this.camera; // OrbitControl の登録カメラを変更
-
     if (this.helper.dimension === 2) {
       // 2次元に切り替わった場合は、ポジションと回転角をリセットする
       const pos = this.OrthographicCamera.position;
@@ -330,6 +330,57 @@ export class SceneService {
 
   public labelRendererDomElement(): Node {
     return this.labelRenderer.domElement;
+  }
+
+  public toScreenPosition(obj:any, camera:any)
+  {
+    var vector = new THREE.Vector3();
+
+    var widthHalf = 0.5*this.Width;
+    var heightHalf = 0.5*this.Height;
+
+    obj.updateMatrixWorld();
+    vector.setFromMatrixPosition(obj.matrixWorld);
+    vector.project(camera);
+
+    vector.x = ( vector.x * widthHalf ) + widthHalf;
+    vector.y = - ( vector.y * heightHalf ) + heightHalf;
+
+    return { 
+        x: vector.x,
+        y: vector.y
+    };
+
+  };
+
+  public myMove(x:any,y:any) {
+      var parent = document.getElementById("graphics-locator");
+      var child = document.getElementById("graphics-locator-child");
+      var pos = 50;
+      parent.style.left = x + 'px';
+      parent.style.top = y + 'px';
+      parent.style.display = "block";
+      clearInterval(this.id);
+      this.id = setInterval(frame, 10);
+      function frame() {
+          if (pos <= 0) {
+              clearInterval(this.id);
+              parent.style.display = "none";
+          } else {
+              pos -= 1;
+              child.style.width = pos + '%';
+              child.style.height = pos + '%';
+              child.style.top = 50 - pos/2 + '%';
+              child.style.left = 50 - pos/2 + '%';
+          }
+      }
+  }
+
+  public getScreenPosition(obj){
+    var position = this.toScreenPosition(obj,this.camera)
+    // var header = document.querySelector('.header');
+    // var body_container = document.querySelector('.body-container');
+    this.myMove(position.x,(position.y + 133))
   }
 
   // リサイズ

--- a/src/app/components/three/three.component.html
+++ b/src/app/components/three/three.component.html
@@ -3,7 +3,10 @@
     <div id="screenArea">
         <app-max-min></app-max-min>
         <canvas #myCanvas id="myCanvas" style="overflow: hidden; position: absolute" (mousedown)="onMouseDown($event)" (mouseup)="onMouseUp($event)" (mousemove)="onMouseMove($event)">
-    </canvas>
+        </canvas>
+        <div id="graphics-locator" style="left: 396px; top: 456.106px; ">
+            <div id="graphics-locator-child" style="width: 60%; height: 60%; top: 20%; left: 20%;"></div>
+        </div>
     </div>
 </div>
 <div id="download">

--- a/src/app/components/three/three.component.scss
+++ b/src/app/components/three/three.component.scss
@@ -11,6 +11,32 @@
     position: relative;
 }
 
+#graphics-locator {
+    display: none;
+    max-width: 200px;
+    max-height: 200px;
+    width: 200px;
+    height: 200px;
+    background: 0 0;
+    border: none;
+    position: absolute;
+    top: 500px;
+    left: 500px;
+    z-index: 11;
+}
+
+#graphics-locator>div {
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    background: rgba(40,157,204,.1);
+    border: 2px solid #289dcc;
+    border-radius: 50%;
+    margin-left: -50%;
+    margin-top: -50%;
+    z-index: 11;
+}
+
 // i.fas {
 //     -webkit-font-smoothing: antialiased;
 //     -moz-osx-font-smoothing: grayscale;

--- a/src/app/components/three/three.service.ts
+++ b/src/app/components/three/three.service.ts
@@ -79,6 +79,7 @@ export class ThreeService {
     this.fixNode.ClearData();
     this.fixMember.ClearData();
     this.joint.ClearData();
+    this.points.ClearData();
     this.panel.changeData();
     this.load.ResetData();
     this.disg.ClearData();
@@ -165,7 +166,6 @@ export class ThreeService {
   // データの選択を処理する
   public selectChange(mode: string, index: number, index_sub: any): void {
     //console.log("selectChange", mode, index, index_sub);
-
     switch (mode) {
       case "nodes":
         this.node.selectChange(index);
@@ -180,7 +180,7 @@ export class ThreeService {
         break;
 
       case "notice-points":
-        this.points.selectChange(index);
+        this.points.selectChange(index,index_sub);
         break;
 
       case "joints":
@@ -218,6 +218,7 @@ export class ThreeService {
     this.fixNode.ClearData();
     this.fixMember.ClearData();
     this.joint.ClearData();
+    this.points.ClearData();
     this.panel.ClearData();
     this.load.ClearData();
     this.disg.ClearData();
@@ -236,7 +237,6 @@ export class ThreeService {
     if (this.currentIndex === currentPage) {
       return;
     }
-
     switch (this.mode) {
       case "elements":
         break;
@@ -294,7 +294,6 @@ export class ThreeService {
         );
         break;
 
-      // 断面力
       case "fsec":
       case "comb_fsec":
       case "pick_fsec":
@@ -310,14 +309,6 @@ export class ThreeService {
           this.secForce.currentRadio === 'momentZ') {
           key = 'z';
         }
-
-        // console.log('#this.secForce.currentRadio', this.secForce.currentRadio);
-        // console.log('#this.secForce.value_ranges', this.secForce.value_ranges);
-        // console.log('#this.mode', this.mode);
-        // console.log('#currentPage', currentPage);
-        // console.log('#this.secForce.currentRadio', this.secForce.currentRadio);
-        // console.log('#key', key);
-
         this.max_min.getMaxMinValue(
           this.secForce.value_ranges,
           this.mode,
@@ -346,6 +337,7 @@ export class ThreeService {
       this.fixNode.visibleChange(false);
       this.fixMember.visibleChange(false);
       this.joint.visibleChange(false);
+      this.points.visibleChange(false);
       this.panel.visibleChange(true, 0.3);
       this.load.visibleChange(false, false);
       this.disg.visibleChange(false);
@@ -359,6 +351,7 @@ export class ThreeService {
       this.fixNode.visibleChange(false);
       this.fixMember.visibleChange(false);
       this.joint.visibleChange(false);
+      this.points.visibleChange(false);
       this.panel.visibleChange(true, 0.3);
       this.load.visibleChange(false, false);
       this.disg.visibleChange(false);
@@ -372,6 +365,7 @@ export class ThreeService {
       this.fixNode.visibleChange(false);
       this.fixMember.visibleChange(false);
       this.joint.visibleChange(false);
+      this.points.visibleChange(true);
       this.panel.visibleChange(true, 0.3);
       this.load.visibleChange(false, false);
       this.disg.visibleChange(false);
@@ -385,6 +379,7 @@ export class ThreeService {
       this.fixNode.visibleChange(false);
       this.fixMember.visibleChange(false);
       this.joint.visibleChange(true);
+      this.points.visibleChange(false);
       this.panel.visibleChange(true, 0.3);
       this.load.visibleChange(false, false);
       this.disg.visibleChange(false);
@@ -398,6 +393,7 @@ export class ThreeService {
       this.fixNode.visibleChange(false);
       this.fixMember.visibleChange(false);
       this.joint.visibleChange(false);
+      this.points.visibleChange(false);
       this.panel.visibleChange(true);
       this.load.visibleChange(false, false);
       this.disg.visibleChange(false);
@@ -411,6 +407,7 @@ export class ThreeService {
       this.fixNode.visibleChange(true);
       this.fixMember.visibleChange(false);
       this.joint.visibleChange(false);
+      this.points.visibleChange(false);
       this.panel.visibleChange(true, 0.3);
       this.load.visibleChange(false, false);
       this.disg.visibleChange(false);
@@ -424,6 +421,7 @@ export class ThreeService {
       this.fixNode.visibleChange(false);
       this.fixMember.visibleChange(true);
       this.joint.visibleChange(false);
+      this.points.visibleChange(false);
       this.panel.visibleChange(true, 0.3);
       this.load.visibleChange(false, false);
       this.disg.visibleChange(false);
@@ -442,6 +440,7 @@ export class ThreeService {
         this.fixNode.visibleChange(true);
         this.fixMember.visibleChange(true);
         this.joint.visibleChange(true);
+        this.points.visibleChange(false);
         this.panel.visibleChange(true, 0.3);
         this.load.visibleChange(true, true);
       }
@@ -452,6 +451,7 @@ export class ThreeService {
         this.fixNode.visibleChange(false);
         this.fixMember.visibleChange(false);
         this.joint.visibleChange(false);
+        this.points.visibleChange(false);
         this.panel.visibleChange(true, 0.3);
         this.load.visibleChange(true, true);
       }
@@ -467,6 +467,7 @@ export class ThreeService {
       this.fixNode.visibleChange(false);
       this.fixMember.visibleChange(false);
       this.joint.visibleChange(false);
+      this.points.visibleChange(false);
       this.panel.visibleChange(true, 0.3);
       this.load.visibleChange(false, false);
       this.disg.visibleChange(true);
@@ -481,6 +482,7 @@ export class ThreeService {
       this.fixNode.visibleChange(false);
       this.fixMember.visibleChange(false);
       this.joint.visibleChange(false);
+      this.points.visibleChange(false);
       this.panel.visibleChange(false);
       this.load.visibleChange(false, false);
       this.disg.visibleChange(false);
@@ -494,6 +496,7 @@ export class ThreeService {
       this.fixNode.visibleChange(false);
       this.fixMember.visibleChange(false);
       this.joint.visibleChange(false);
+      this.points.visibleChange(false);
       this.panel.visibleChange(false);
       this.load.visibleChange(false, false);
       this.disg.visibleChange(false);
@@ -508,6 +511,7 @@ export class ThreeService {
       this.fixNode.visibleChange(false);
       this.fixMember.visibleChange(false);
       this.joint.visibleChange(false);
+      this.points.visibleChange(false);
       this.panel.visibleChange(false);
       this.load.visibleChange(false, false);
       this.disg.visibleChange(false);
@@ -522,6 +526,7 @@ export class ThreeService {
       this.fixNode.visibleChange(false);
       this.fixMember.visibleChange(false);
       this.joint.visibleChange(false);
+      this.points.visibleChange(false);
       this.panel.visibleChange(false);
       this.load.visibleChange(false, false);
       this.disg.visibleChange(false);
@@ -557,6 +562,7 @@ export class ThreeService {
       this.fixNode.visibleChange(false);
       this.fixMember.visibleChange(false);
       this.joint.visibleChange(false);
+      this.points.visibleChange(false);
       this.panel.visibleChange(false);
       this.load.visibleChange(false, false);
       this.disg.visibleChange(false);


### PR DESCRIPTION
#43 
・着目点メニューを開いた際に「着目点」を点モデルとして表示
・着目点メニューの「部材No」「部材長」セルを選択した場合は部材を赤色でハイライト
・着目点メニューの「i端からの距離」セルを選択した場合は着目点を赤色でハイライト

#327 
「節点」「部材」「荷重」の入力セルを選択した際に下記の処理を追加
・選択したモデルの周囲に青い円が出現・収縮して節点の位置をハイライトする機能を追加
・節点の場合は節点を中心として青い円が出現
・部材の場合はi端を中心として青い円が出現
・要素荷重の場合は「部材No」>「1」の部材のi端を中心として青い円が出現
・節点荷重の場合は節点を中心として青い円が出現