### PR TITLE
部材の材料番号が未設定の場合に0が補完されてBEに渡される問題の修正 task1272

### DIFF
--- a/src/app/components/input/input-members/input-members.service.ts
+++ b/src/app/components/input/input-members/input-members.service.ts
@@ -85,7 +85,7 @@ export class InputMembersService {
       jsonData[key] = {
         'ni': (ni == null) ? empty : ni,
         'nj': (nj == null) ? empty : nj,
-        'e': (e == null) ? empty : e,
+        'e': e,
         'cg': (cg == null) ? empty : cg
       };
 


### PR DESCRIPTION
https://www.notion.so/1f9b586afd1180568775eb9398b9586c