### PR TITLE
DEFINEに欠番がある場合に末尾の番号までCOMBINEの列(D△)が表示されない問題の修正 task1561

### DIFF
--- a/src/app/components/input/input-define/input-define.service.ts
+++ b/src/app/components/input/input-define/input-define.service.ts
@@ -76,10 +76,14 @@ export class InputDefineService {
   }
 
   // 補助関数 ///////////////////////////////////////////////////////////////
-  // 有効な DEFINEケース数を調べる
+
+  /**
+   * DEFINEケース番号の最大値を返す
+   * @returns DEFINEケース番号の最大値
+   */
   public getDefineCaseCount(): number {
     const dict = this.getDefineJson();
-    return Object.keys(dict).length;
+    return Math.max(...Object.keys(dict).map(k => Number(k)));
   }
 
   


### PR DESCRIPTION
https://www.notion.so/FrameWeb-DEFINE-COMBINE-D-255b586afd118052af89d18a8126ddf2